### PR TITLE
fix: prevent insertCSS rule accumulation on 24/7 kiosks

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -738,11 +738,13 @@ function createWindow() {
 function setupCursorHiding() {
   let cursorTimeout = null;
   let cursorHidden = false;
+  let cursorCssKey = null;
 
   const hideCursor = () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.insertCSS('html.cursor-hidden, html.cursor-hidden * { cursor: none !important; }')
         .then((key) => {
+          cursorCssKey = key;
           mainWindow.webContents.executeJavaScript('document.documentElement.classList.add("cursor-hidden")');
           cursorHidden = true;
         })
@@ -752,6 +754,10 @@ function setupCursorHiding() {
 
   const showCursor = () => {
     if (cursorHidden && mainWindow && !mainWindow.isDestroyed()) {
+      if (cursorCssKey) {
+        mainWindow.webContents.removeInsertedCSS(cursorCssKey).catch(() => {});
+        cursorCssKey = null;
+      }
       mainWindow.webContents.executeJavaScript('document.documentElement.classList.remove("cursor-hidden")')
         .catch(() => {});
       cursorHidden = false;


### PR DESCRIPTION
Closes #40. Stores CSS key from insertCSS(), calls removeInsertedCSS() in showCursor().