### PR TITLE
ci: bump build-rpm/deb SHA pin to .github#35 (raw-armor GPG)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
   rpm:
     needs: [wait-for-pwa]
     if: always() && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xibo-players/.github/.github/workflows/build-rpm.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
     with:
       package-name: xiboplayer-electron
       build-command: 'pnpm run build:linux'
@@ -56,7 +56,7 @@ jobs:
   deb:
     needs: [wait-for-pwa]
     if: always() && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xibo-players/.github/.github/workflows/build-deb.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
     with:
       package-name: xiboplayer-electron
       build-command: 'pnpm run build:linux'


### PR DESCRIPTION
Pins to .github main @ 99b65f33 which drops the base64 layer. Secrets now hold raw ASCII armor — without this bump, RPM+DEB signing in this repo continues to fail with 'no valid OpenPGP data found'. Companion pin bumps landed for kiosk (#155) and the other sibling repos.