### PR TITLE
refactor(spec): use literal Version (match chromium pattern)

### DIFF
--- a/rpm/build-rpm.sh
+++ b/rpm/build-rpm.sh
@@ -56,8 +56,9 @@ echo "    $TARBALL ($(du -h "$TARBALL" | cut -f1))"
 # ── Build RPM ─────────────────────────────────────────────────────────
 cp "$SPEC_DIR/xiboplayer-electron.spec" ~/rpmbuild/SPECS/
 echo "==> Running rpmbuild..."
-rpmbuild -ba ~/rpmbuild/SPECS/xiboplayer-electron.spec \
-    --define "_version $VERSION"
+# Spec uses literal Version: line (matches chromium); the release-xiboplayer
+# Ansible playbook bumps it. No --define "_version" needed.
+rpmbuild -ba ~/rpmbuild/SPECS/xiboplayer-electron.spec
 
 # ── Collect and display results ───────────────────────────────────────
 pkg_collect_rpms ~/rpmbuild

--- a/rpm/xiboplayer-electron.spec
+++ b/rpm/xiboplayer-electron.spec
@@ -8,7 +8,7 @@
 %global __requires_exclude ^(libc\\.so\\(\\)|libdl\\.so\\.2|libpthread\\.so\\.0|librt\\.so\\.1|libffmpeg\\.so)
 
 Name:           xiboplayer-electron
-Version:        %{_version}
+Version:        0.7.19
 Release:        1%{?dist}
 Summary:        Xibo digital signage player (Electron)
 


### PR DESCRIPTION
Drops the %{_version} macro indirection. Spec gets a literal Version: line, build-rpm.sh drops the --define _version flag.

Solves the workflow_dispatch-from-main version-detection failure (spec macro stripped → jq fallback → jq missing in Fedora container → exit 127).

Companion update to release-xiboplayer.yml playbook to bump electron Version like chromium.