### PR TITLE
chore: unbump 0.7.20 → 0.7.19 so playbook can bump SDK+players in lockstep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xiboplayer/electron",
-  "version": "0.7.20",
+  "version": "0.7.19",
   "description": "xiboplayer - Electron Kiosk Wrapper for PWA",
   "main": "src/main.js",
   "author": "Pau Aliagas <linuxnow@gmail.com>",

--- a/rpm/xiboplayer-electron.spec
+++ b/rpm/xiboplayer-electron.spec
@@ -8,7 +8,7 @@
 %global __requires_exclude ^(libc\\.so\\(\\)|libdl\\.so\\.2|libpthread\\.so\\.0|librt\\.so\\.1|libffmpeg\\.so)
 
 Name:           xiboplayer-electron
-Version:        0.7.20
+Version:        0.7.19
 Release:        1%{?dist}
 Summary:        Xibo digital signage player (Electron)
 
@@ -157,9 +157,6 @@ if [ $1 -eq 0 ] ; then
 fi
 
 %changelog
-* Thu Apr 16 2026 Pau Aliagas <linuxnow@gmail.com> - 0.7.20-1
-- GPU detection: virtio-gpu / QEMU / VMware SVGA force software rendering to avoid crash loop. Real GPUs unchanged.
-
 * Tue Apr 14 2026 Pau Aliagas <linuxnow@gmail.com> - 0.7.19-1
 - Stability fixes + chromium instrumentation: proxy crash on closed client stream, stale-cache age log calculation, chromium launcher renderer log forwarding, SECURITY.md, SBOM CI.
 


### PR DESCRIPTION
Companion to xibo-players/xiboplayer-chromium#75. GPU fix from #61 stays; only the version bump is reverted.