### PR TITLE
fix(tray): include resources/icon.png in app.asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     },
     "files": [
       "src/**/*",
+      "resources/icon.png",
       "package.json"
     ],
     "linux": {

--- a/rpm/xiboplayer-electron.spec
+++ b/rpm/xiboplayer-electron.spec
@@ -9,7 +9,7 @@
 
 Name:           xiboplayer-electron
 Version:        0.7.21
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Xibo digital signage player (Electron)
 
 License:        AGPL-3.0-or-later
@@ -157,6 +157,9 @@ if [ $1 -eq 0 ] ; then
 fi
 
 %changelog
+* Thu Apr 16 2026 Pau Aliagas <linuxnow@gmail.com> - 0.7.21-2
+- Fix tray icon not loading: include resources/icon.png in app.asar
+
 * Thu Apr 16 2026 Pau Aliagas <linuxnow@gmail.com> - 0.7.21-1
 - GPU fix followup: lower best_rank init so virtio rank -1 is selectable (bug in 0.7.20 virtual-GPU detection)
 


### PR DESCRIPTION
Closes #63

## Summary

- `src/main.js:845` loads the tray icon from `../resources/icon.png` relative to its packaged location (inside `app.asar`), but `package.json` `build.files` never packed `resources/icon.png` into the asar → `new Tray(iconPath)` threw, no tray appeared.
- Narrow fix: add the single file `resources/icon.png` to the `files` allowlist.
- Bumped RPM `Release:` 1 → 2 (player-only, no SDK / no Version bump).

## Test plan

- [ ] DNF upgrade 0.7.21-1 → 0.7.21-2 on a Fedora 43 kiosk (Boxes or bare metal)
- [ ] Start `xiboplayer-electron.service` manually → confirm `journalctl --user -u xiboplayer-electron` shows no `[Tray] Failed to create system tray` line
- [ ] Visual: tray icon visible in GNOME top bar (non-kiosk session) or in test-image kiosk where AyatanaIndicator tray extension is enabled
- [ ] Regression: chromium (0.7.21-1) still boots under Boxes with the virtio-GPU → software-render code path