### PR TITLE
chore: post-rename sweep — xibo-players → xiboplayer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
   rpm:
     needs: [wait-for-pwa]
     if: always() && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@b32631e9f28d649efea2873282c79bb439c13751  # main
+    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@b32631e9f28d649efea2873282c79bb439c13751  # main
     with:
       package-name: xiboplayer-electron
       build-command: 'pnpm run build:linux'
@@ -56,7 +56,7 @@ jobs:
   deb:
     needs: [wait-for-pwa]
     if: always() && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
+    uses: xiboplayer/.github/.github/workflows/build-deb.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
     with:
       package-name: xiboplayer-electron
       build-command: 'pnpm run build:linux'
@@ -70,7 +70,7 @@ jobs:
 
   release:
     needs: [rpm, deb]
-    uses: xibo-players/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: xiboplayer-electron
       description: 'Electron-based Xibo digital signage player with hardware acceleration.'

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ redirects back to the setup screen automatically.
 
 ### Auto-authorize via CMS API (optional)
 
-By default, new displays must be manually authorized by a CMS administrator. To skip this step, add OAuth2 API credentials to `config.json` — see the [PWA README](https://github.com/xibo-players/xiboplayer-pwa#auto-authorize-via-cms-api-optional) for full setup instructions including CMS Application configuration:
+By default, new displays must be manually authorized by a CMS administrator. To skip this step, add OAuth2 API credentials to `config.json` — see the [PWA README](https://github.com/xiboplayer/xiboplayer-pwa#auto-authorize-via-cms-api-optional) for full setup instructions including CMS Application configuration:
 
 ```json
 {
@@ -460,7 +460,7 @@ rm -rf ~/.local/share/applications/xiboplayer-electron.desktop
 
 ## Support
 
-- **GitHub Issues:** https://github.com/xibo-players/xiboplayer-electron/issues
+- **GitHub Issues:** https://github.com/xiboplayer/xiboplayer-electron/issues
 
 ## Credits
 

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -88,7 +88,7 @@ Description=xiboplayer - Digital Signage (Electron)
 After=graphical-session.target
 Wants=graphical-session.target
 PartOf=graphical-session.target
-Documentation=https://github.com/xibo-players/xiboplayer-electron
+Documentation=https://github.com/xiboplayer/xiboplayer-electron
 
 [Service]
 Type=simple

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://xiboplayer.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/xibo-players/xiboplayer-electron.git"
+    "url": "https://github.com/xiboplayer/xiboplayer-electron.git"
   },
   "scripts": {
     "start": "electron .",

--- a/rpm/xiboplayer-electron-rocky.spec
+++ b/rpm/xiboplayer-electron-rocky.spec
@@ -120,7 +120,7 @@ Description=Xibo Player - Digital Signage (Electron)
 After=graphical-session.target
 Wants=graphical-session.target
 PartOf=graphical-session.target
-Documentation=https://github.com/xibo-players/xiboplayer-electron
+Documentation=https://github.com/xiboplayer/xiboplayer-electron
 StartLimitIntervalSec=60
 StartLimitBurst=5
 

--- a/rpm/xiboplayer-electron.spec
+++ b/rpm/xiboplayer-electron.spec
@@ -106,7 +106,7 @@ Description=Xibo Player - Digital Signage (Electron)
 After=graphical-session.target
 Wants=graphical-session.target
 PartOf=graphical-session.target
-Documentation=https://github.com/xibo-players/xiboplayer-electron
+Documentation=https://github.com/xiboplayer/xiboplayer-electron
 StartLimitIntervalSec=60
 StartLimitBurst=5
 


### PR DESCRIPTION
## Summary

6 files updated post-rename. Operator-facing refs in README, package.json repo URL, build workflow `uses:`, RPM specs, deb build script.

## Intentionally NOT touched

- `rpm/xibo-player.spec` URL field references `github.com/xibo/xibo-players` — neither old nor new org, looks like a legacy upstream URL. Needs separate operator review.
- Historical changelog entries citing `xibo-players/xiboplayer#332` — don't rewrite history.
- Lockfiles, node_modules, dist.

## Refs

Companion to xiboplayer/xiboplayer-www#60, xiboplayer/xiboplayer-kiosk#201, xiboplayer/.github#42, xiboplayer/xiboplayer.github.io#17.